### PR TITLE
Changed requires so that importing `rugged` and `pry` work for me.

### DIFF
--- a/osm100.rb
+++ b/osm100.rb
@@ -1,9 +1,14 @@
 #!/usr/bin/ruby
 
+require 'rubygems'
+
 require 'yaml'
-require 'rugged'
 require 'set'
 require 'pry'
+
+require 'bundler'
+Bundler.setup(:default)
+require 'rugged'
 
 @working_dir = File.join(File.dirname(__FILE__), 'tmp')
 


### PR DESCRIPTION
I never got to the root of the problem, but when I first checked
out the project, it wasn't able to find the `rugged` package which
was installed via bundler. Installing a separate version via `gem`
wasn't able to use SSL. It seems that the version of `rugged`
built from git was able to use SSL, but wasn't being found by
`rubygems`, and a bit of searching led me to include the bundler
setup lines. It now works - but I can't explain why :-)
